### PR TITLE
Fail safe on check flag

### DIFF
--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -9,7 +9,8 @@
   failed_when: false
   register: root_pwd_check
   tags: mariadb
-  debug:
+
+- debug:
     msg: root_pwd_check = { root_pwd_check }
 
 - name: Set MariaDB root password for the first time (root@localhost)

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -11,7 +11,7 @@
   tags: mariadb
 
 - debug:
-    msg: root_pwd_check = { root_pwd_check }
+    msg: root_pwd_check = {{ root_pwd_check }}
 
 - name: Set MariaDB root password for the first time (root@localhost)
   mysql_user:

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -1,37 +1,36 @@
 # roles/mariadb/tasks/root-password.yml
 ---
 
-# This command will fail when the root password was set previously
-- name: Check if root password is set
-  shell: >
-    mysqladmin -u root status
-  changed_when: false
-  failed_when: false
-  register: root_pwd_check
-  tags: mariadb
+- block:
+  # This command will fail when the root password was set previously
+  - name: Check if root password is set
+    shell: >
+      mysqladmin -u root status
+    changed_when: false
+    failed_when: false
+    register: root_pwd_check
+    tags: mariadb
 
-- debug:
-    msg: root_pwd_check.rc = {{ root_pwd_check }}
+  - name: Set MariaDB root password for the first time (root@localhost)
+    mysql_user:
+      name: root
+      password: "{{ mariadb_root_password }}"
+      host: localhost
+      state: present
+    when: root_pwd_check.rc == 0
+    tags: mariadb
 
-- name: Set MariaDB root password for the first time (root@localhost)
-  mysql_user:
-    name: root
-    password: "{{ mariadb_root_password }}"
-    host: localhost
-    state: present
-  when: root_pwd_check.rc == 0
-  tags: mariadb
-
-- name: Set MariaDB root password for 127.0.0.1, ::1
-  mysql_user:
-    name: root
-    password: "{{ mariadb_root_password }}"
-    host: "{{ item }}"
-    login_user: root
-    login_password: "{{ mariadb_root_password }}"
-    state: present
-  with_items:
-    - ::1
-    - 127.0.0.1
-  when: root_pwd_check.rc == 0
-  tags: mariadb
+  - name: Set MariaDB root password for 127.0.0.1, ::1
+    mysql_user:
+      name: root
+      password: "{{ mariadb_root_password }}"
+      host: "{{ item }}"
+      login_user: root
+      login_password: "{{ mariadb_root_password }}"
+      state: present
+    with_items:
+      - ::1
+      - 127.0.0.1
+    when: root_pwd_check.rc == 0
+    tags: mariadb
+  when: not ansible_check_mode

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -1,10 +1,6 @@
 # roles/mariadb/tasks/root-password.yml
 ---
 
-- hosts: all
-  vars:
-    root_pwd_check: "Check mode default."
-
 # This command will fail when the root password was set previously
 - name: Check if root password is set
   shell: >
@@ -15,7 +11,7 @@
   tags: mariadb
 
 - debug:
-    msg: root_pwd_check = {{ root_pwd_check }}
+    msg: root_pwd_check.rc = {{ root_pwd_check }}
 
 - name: Set MariaDB root password for the first time (root@localhost)
   mysql_user:

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -9,6 +9,8 @@
   failed_when: false
   register: root_pwd_check
   tags: mariadb
+  debug:
+    msg: root_pwd_check = { root_pwd_check }
 
 - name: Set MariaDB root password for the first time (root@localhost)
   mysql_user:

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -1,6 +1,10 @@
 # roles/mariadb/tasks/root-password.yml
 ---
 
+- hosts: all
+  vars:
+    root_pwd_check: "Check mode default."
+
 # This command will fail when the root password was set previously
 - name: Check if root password is set
   shell: >


### PR DESCRIPTION
When Ansible is running in check mode, it does not execute shell commands. This resulted in an empty variable `root_pwd_check` in check mode. The changed version of the code is not executed in check mode.